### PR TITLE
Updated the  baseline_summarization_chat notebook for dynamic conversation selection

### DIFF
--- a/courses/agent_assist/baseline_summarization_chat.ipynb
+++ b/courses/agent_assist/baseline_summarization_chat.ipynb
@@ -289,7 +289,7 @@
     "else:\n",
     "    conversation_id_to_view = available_ids[0]  # Fallback if neither '034' nor '047' exists\n",
     "\n",
-    "print(f\"TARGET_CONVERSATION_ID: {conversation_id_to_view}\")  # Confirm which conversation ID will be filtered\n",
+    "print(f\"Selected conversation ID: {conversation_id_to_view}\")  # Confirm which conversation ID will be filtered\n",
     "\n",
     "# Create a boolean mask where the 'conversation_id' matches the conversation_id_to_view\n",
     "mask = eval_df['conversation_id'] == conversation_id_to_view  # Can update conversation_id_to_view to view other conversations\n",

--- a/courses/agent_assist/baseline_summarization_chat.ipynb
+++ b/courses/agent_assist/baseline_summarization_chat.ipynb
@@ -271,9 +271,31 @@
    },
    "outputs": [],
    "source": [
+    "import pandas as pd\n",
+    "\n",
+    "# Convert the list of transcripts into a pandas DataFrame\n",
     "eval_df = pd.DataFrame(all_transcripts)\n",
-    "mask = eval_df['conversation_id']=='034' #Update to view other conversations\n",
-    "eval_df[mask]"
+    "\n",
+    "# Get all unique conversation IDs in the dataset to see which conversations are present\n",
+    "available_ids = eval_df['conversation_id'].unique()\n",
+    "print(\"Available Conversation IDs (First 10):\")\n",
+    "print(available_ids[:10])  # Display the first 10 IDs as a quick check\n",
+    "\n",
+    "# Select a specific conversation to analyze\n",
+    "if '034' in available_ids:\n",
+    "    conversation_id_to_view = '034'\n",
+    "elif '047' in available_ids:\n",
+    "    conversation_id_to_view = '047'\n",
+    "else:\n",
+    "    conversation_id_to_view = available_ids[0]  # Fallback if neither '034' nor '047' exists\n",
+    "\n",
+    "print(f\"TARGET_CONVERSATION_ID: {conversation_id_to_view}\")  # Confirm which conversation ID will be filtered\n",
+    "\n",
+    "# Create a boolean mask where the 'conversation_id' matches the conversation_id_to_view\n",
+    "mask = eval_df['conversation_id'] == conversation_id_to_view  # Can update conversation_id_to_view to view other conversations\n",
+    "\n",
+    "# Apply the mask to retrieve only the rows corresponding to the selected conversation\n",
+    "eval_df[mask] \n"
    ]
   },
   {
@@ -471,7 +493,7 @@
     "id": "hlmNZLofrzeA"
    },
    "source": [
-    "Now we can explore the output from the baseline summarization model for the conversation (`034`) that you looked at earlier."
+    "Now we can explore the output from the baseline summarization model for the conversation selected as `conversation_id_to_view` that you looked at earlier."
    ]
   },
   {
@@ -485,9 +507,16 @@
     "import pprint\n",
     "\n",
     "summ_df = pd.DataFrame(results)\n",
-    "mask = summ_df['transcript_id']=='034'\n",
+    "mask = summ_df['transcript_id']==conversation_id_to_view\n",
     "pprint.pprint(summ_df[mask].iloc[0]['summary'])"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Here are the updates:
- Modified evaluation DataFrame filtering to use the `conversation_id_to_view` variable instead of hardcoded values to resolve inconsistencies related to conversation IDs in Step 1, third code block.
- Updated baseline summarization exploration code to reference the dynamic conversation variable (`conversation_id_to_view`) for consistency.
